### PR TITLE
Have Bde::pipe also work when '/dev/stdout' does not exist

### DIFF
--- a/lib/LINZ/Bde.pm
+++ b/lib/LINZ/Bde.pm
@@ -501,6 +501,8 @@ sub pipe
     my $outputfile = '/dev/stdout';
     if ( ! -p $outputfile )
     {
+        print STDERR "WARNING: /dev/stdout is not a pipe so "
+                   . "Bde::pipe will use a temporary file\n";
         my ($fh, $tmpfile) = File::Temp::tempfile();
         close($fh);
         my $result = $self->copy($outputfile, @options);

--- a/lib/LINZ/Bde.pm
+++ b/lib/LINZ/Bde.pm
@@ -499,8 +499,20 @@ sub pipe
     my $opts = ref($options[0]) ? $options[0] : {@options};
 
     my $outputfile = '/dev/stdout';
-    die "Pipe is not supported on this system (lack of $outputfile named pipe)"
-        unless -p $outputfile;
+    if ( ! -p $outputfile )
+    {
+        my ($fh, $tmpfile) = File::Temp::tempfile();
+        close($fh);
+        my $result = $self->copy($outputfile, @options);
+        if ($result->{nerrors} > 0)
+        {
+            die (@{$result->{errors}});
+        }
+        open(my $tabledatafh, "<$tmpfile") || die ("Cannot open $tmpfile: $!");
+        unlink $tmpfile if $tmpfile && ! $self->{keepfiles};
+        return $tabledatafh;
+    }
+
 
     my $exe = _bdecopy();
     my ($cfgtmp, @copyopts) = $self->_copy_opts($opts);


### PR DESCRIPTION
Suprisingly, Travis does not have that file either !
Create a temporary file in those cases.

Closes #26