### PR TITLE
Use stdout support in bde_copy when available

### DIFF
--- a/configure
+++ b/configure
@@ -13,4 +13,6 @@ ${PERL} Makefile.PL
 cat <<EOF >> Makefile
 deb:
 	dpkg-buildpackage -b -us -uc
+
+check: test
 EOF


### PR DESCRIPTION
Starting with bde_copy 1.3.0 there is built-in support for
outputting to stdout so we don't need to resort to /dev/stdout