### PR TITLE
[travis] omit language specification again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: bionic
-language: perl
 
 perl:
   - "5.26"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+liblinz-bde-perl (1.2.0-1linz~trusty1) trusty; urgency=medium
+
+  * New upstream version
+
+ -- Ivan Mincik <imincik@linz.govt.nz>  Tue, 10 Sep 2019 11:46:38 +0200
+
 liblinz-bde-perl (1.1.1-1linz~bionic1) bionic; urgency=medium
 
   * New upstream version


### PR DESCRIPTION
It was added back with e771fb716cb92131b3adbf3915edfa4dd24dda1a
but it isn't clear whether it was a good idea, given it was
removed with PR #33 to fix #32