### PR TITLE
[travis] omit language specification again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: bionic
-language: perl
 
 perl:
   - "5.26"


### PR DESCRIPTION
It was added back with e771fb716cb92131b3adbf3915edfa4dd24dda1a
but it isn't clear whether it was a good idea, given it was
removed with PR #33 to fix #32