### PR TITLE
ci: add package building and publishing steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,8 @@ jobs:
             cpanminus \
             debhelper \
             fakeroot \
-            libfile-which-perl
+            libfile-which-perl \
+            libtest-exception-perl
         cpanm \
             File::Which \
             Module::Build \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - packagecloud
     - 'release-*'
   pull_request:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,3 +68,37 @@ jobs:
         # unpackaged on packagecloud for bionic, see
         # https://github.com/linz/linz-bde-copy/issues/44
         #sudo dpkg -i ../liblinz-bde-perl*.deb
+
+  package:
+    if: ${{ success() }}
+    name: Package for Debian
+    runs-on: ubuntu-18.04
+    strategy:
+        matrix:
+            distro: [ 'bionic' ]
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Determine packagecloud publication target
+      run: |
+        # TODO: it would be nice to turn this into a single-liner in
+        #       github-action syntax
+        echo "GitHub ref: ${{ github.ref }}"
+        echo "GitHub event_name: ${{ github.event_name }}"
+        REPO=
+        if test "${{ github.event_name }}" = 'push'; then
+          if expr "${{ github.ref }}" : "refs/tags/" > /dev/null; then
+            REPO=test
+          elif test "${{ github.ref }}" = 'refs/heads/packagecloud' -o
+               test "${{ github.ref }}" = 'refs/heads/master'
+          then
+            REPO=dev
+          fi
+        fi
+        echo "REPO: $REPO"
+        echo ::set-env name=REPO::"$REPO"
+
+    - uses: linz/linz-software-repository@master
+      with:
+        packagecloud_token: ${{ secrets.LINZCI_PACKAGECLOUD_TOKEN }}
+        publish_to_repository: ${{ env.REPO }}

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,8 @@ Section: perl
 Priority: optional
 Build-Depends: debhelper (>= 7)
 Build-Depends-Indep: perl (>= 5.8),
- libmodule-build-perl
+ libmodule-build-perl,
+ libtest-exception-perl
 Standards-Version: 3.9.5
 Maintainer: Jeremy Palmer (LINZ) <jpalmer@linz.govt.nz>
 Homepage: http://www.linz.govt.nz


### PR DESCRIPTION
Builds packages using linz-software-repository action
Publish packages:
  - to "dev" repository on push to master or packagecloud branches
  - to "test" repository on tag