### PR TITLE
ci: fix shell syntax for packagecloud upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,8 +91,8 @@ jobs:
         if test "${{ github.event_name }}" = 'push'; then
           if expr "${{ github.ref }}" : "refs/tags/" > /dev/null; then
             REPO=test
-          elif test "${{ github.ref }}" = 'refs/heads/packagecloud' -o
-               test "${{ github.ref }}" = 'refs/heads/master'
+          elif test "${{ github.ref }}" = 'refs/heads/packagecloud' \
+                 -o "${{ github.ref }}" = 'refs/heads/master'
           then
             REPO=dev
           fi


### PR DESCRIPTION
Sorry, this was a late addition and didn't notice the
syntax error before. It's only present in this repo.