### PR TITLE
ci: migrate to secure environment setting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,8 +100,7 @@ jobs:
             PACKAGECLOUD_REPOSITORY=dev
           fi
         fi
-        echo "PACKAGECLOUD_REPOSITORY: $PACKAGECLOUD_REPOSITORY"
-        echo ::set-env name=PACKAGECLOUD_REPOSITORY::"$PACKAGECLOUD_REPOSITORY"
+        echo "PACKAGECLOUD_REPOSITORY=$PACKAGECLOUD_REPOSITORY" | tee -a $GITHUB_ENV
 
     - uses: linz/linz-software-repository@v4
       with:


### PR DESCRIPTION
See
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/