### PR TITLE
fix: Remove workflow schedule

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,6 @@ on:
   pull_request:
     branches:
       - '*'
-  schedule:
-    - cron: '0 12 * * 0'
 
 jobs:
   lint:


### PR DESCRIPTION
GitHub unfortunately disables workflows with a schedule on any repo without activity for 60 days. This disabling is silent and invisible, only showing up as a slightly different icon next to the job on the Actions page. Clicking that icon will prompt whether you want to re-enable it. But at that point the damage is already done, in shape of a lot of fiddling to figure out what went wrong, and having to re-push PRs with different contents to actually trigger the now active workflow.

There's been no response from GitHub about this issue yet <https://github.com/orgs/community/discussions/32197>.

This is part of fixing
<https://github.com/linz/ds-infra-team/issues/927>.