### PR TITLE
fix: Don't build on moving OS version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           - '5.32'
           - '5.30'
           - '5.28'
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
+        os: [ubuntu-18.04, ubuntu-20.04]
 
     steps:
       - name: Check out repository
@@ -162,7 +162,7 @@ jobs:
       - lint
       - test
       - package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@v1.2.1


### PR DESCRIPTION
It's bound to break, like it did when Ubuntu 22.04 came around.